### PR TITLE
Use OnePlus sensors for ambient display

### DIFF
--- a/res/xml/doze_settings.xml
+++ b/res/xml/doze_settings.xml
@@ -35,7 +35,7 @@
         android:summary="@string/ambient_display_summary" />
 
     <PreferenceCategory
-        android:key="tilt_sensor"
+        android:key="pickup_sensor"
         android:title="@string/tilt_sensor_title" >
 
         <SwitchPreference

--- a/src/com/custom/ambient/display/DozeService.java
+++ b/src/com/custom/ambient/display/DozeService.java
@@ -28,14 +28,14 @@ public class DozeService extends Service {
     private static final String TAG = "DozeService";
     private static final boolean DEBUG = false;
 
-    private ProximitySensor mProximitySensor;
-    private TiltSensor mTiltSensor;
+    private PocketSensor mPocketSensor;
+    private PickupSensor mPickupSensor;
 
     @Override
     public void onCreate() {
         if (DEBUG) Log.d(TAG, "Creating service");
-        mProximitySensor = new ProximitySensor(this);
-        mTiltSensor = new TiltSensor(this);
+        mPocketSensor = new PocketSensor(this);
+        mPickupSensor = new PickupSensor(this);
 
         IntentFilter screenStateFilter = new IntentFilter(Intent.ACTION_SCREEN_ON);
         screenStateFilter.addAction(Intent.ACTION_SCREEN_OFF);
@@ -53,8 +53,8 @@ public class DozeService extends Service {
         if (DEBUG) Log.d(TAG, "Destroying service");
         super.onDestroy();
         this.unregisterReceiver(mScreenStateReceiver);
-        mProximitySensor.disable();
-        mTiltSensor.disable();
+        mPocketSensor.disable();
+        mPickupSensor.disable();
     }
 
     @Override
@@ -64,14 +64,14 @@ public class DozeService extends Service {
 
     private void onDisplayOn() {
         if (DEBUG) Log.d(TAG, "Display on");
-        mTiltSensor.disable();
-        mProximitySensor.disable();
+        mPickupSensor.disable();
+        mPocketSensor.disable();
     }
 
     private void onDisplayOff() {
         if (DEBUG) Log.d(TAG, "Display off");
-        mTiltSensor.enable();
-        mProximitySensor.enable();
+        mPickupSensor.enable();
+        mPocketSensor.enable();
     }
 
     private BroadcastReceiver mScreenStateReceiver = new BroadcastReceiver() {

--- a/src/com/custom/ambient/display/PickupSensor.java
+++ b/src/com/custom/ambient/display/PickupSensor.java
@@ -32,10 +32,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-public class TiltSensor implements SensorEventListener {
+public class PickupSensor implements SensorEventListener {
 
     private static final boolean DEBUG = false;
-    private static final String TAG = "TiltSensor";
+    private static final String TAG = "PickupSensor";
 
     private static final int SENSOR_WAKELOCK_DURATION = 200;
     private static final int BATCH_LATENCY_IN_MS = 100;
@@ -55,13 +55,13 @@ public class TiltSensor implements SensorEventListener {
 
     private final ExecutorService mExecutorService;
 
-    public TiltSensor(Context context) {
+    public PickupSensor(Context context) {
         mContext = context;
         mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
         mSensorManager = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
         if (mSensorManager != null) {
             mIsGlanceGesture = false;
-            mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_TILT_DETECTOR);
+            mSensor = Utils.findSensorWithType(mSensorManager, "com.oneplus.sensor.pickup");
             if (mSensor == null) {
                 mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_GLANCE_GESTURE, true);
                 mIsGlanceGesture = true;
@@ -107,7 +107,7 @@ public class TiltSensor implements SensorEventListener {
             if (mTiltGestureEnabled) {
                 if (!mIsGlanceGesture) {
                     mSensorManager.registerListener(this, mSensor,
-                            SensorManager.SENSOR_DELAY_NORMAL, BATCH_LATENCY_IN_MS * 1000);
+                            SensorManager.SENSOR_DELAY_NORMAL);
                 } else {
                     if (!mEnabled) {
                         if (!mSensorManager.requestTriggerSensor(mGlanceListener, mSensor)) {

--- a/src/com/custom/ambient/display/PocketSensor.java
+++ b/src/com/custom/ambient/display/PocketSensor.java
@@ -27,10 +27,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-public class ProximitySensor implements SensorEventListener {
+public class PocketSensor implements SensorEventListener {
 
     private static final boolean DEBUG = false;
-    private static final String TAG = "ProximitySensor";
+    private static final String TAG = "PocketSensor";
 
     private static final int POCKET_DELTA_NS = 1000 * 1000 * 1000;
 
@@ -46,19 +46,19 @@ public class ProximitySensor implements SensorEventListener {
 
     private final ExecutorService mExecutorService;
 
-    public ProximitySensor(Context context) {
+    public PocketSensor(Context context) {
         mContext = context;
         mSensorManager = (SensorManager)
                 mContext.getSystemService(Context.SENSOR_SERVICE);
         if (mSensorManager != null) {
-            mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+            mSensor = Utils.findSensorWithType(mSensorManager, "com.oneplus.sensor.pocket");
         }
         mExecutorService = Executors.newSingleThreadExecutor();
     }
 
     @Override
     public void onSensorChanged(SensorEvent event) {
-        boolean isNear = event.values[0] < mSensor.getMaximumRange();
+        boolean isNear = event.values[0] == 1;
         if (mSawNear && !isNear) {
             if (shouldPulse(event.timestamp)) {
                 Utils.launchDozePulse(mContext);

--- a/src/com/custom/ambient/display/Utils.java
+++ b/src/com/custom/ambient/display/Utils.java
@@ -20,12 +20,17 @@ import android.app.ActivityManager;
 import android.app.ActivityManager.RunningServiceInfo;
 import android.content.Context;
 import android.content.Intent;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
 import android.os.UserHandle;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.android.internal.hardware.AmbientDisplayConfiguration;
+
+import java.util.List;
 
 public final class Utils {
 
@@ -152,5 +157,18 @@ public final class Utils {
     protected static boolean sensorsEnabled(Context context) {
         return tiltGestureEnabled(context) || handwaveGestureEnabled(context)
                 || pocketGestureEnabled(context);
+    }
+
+    protected static Sensor findSensorWithType(SensorManager sensorManager, String type) {
+        if (TextUtils.isEmpty(type)) {
+            return null;
+        }
+        List<Sensor> sensorList = sensorManager.getSensorList(Sensor.TYPE_ALL);
+        for (Sensor s : sensorList) {
+            if (type.equals(s.getStringType())) {
+                return s;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This change makes ambient display appear faster when picking up device and makes use of PocketSensor.
Tested and confirmed working on OnePlus 3T on my own unofficial build, other devices shouldn't be affected negatively.